### PR TITLE
Update credits url

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ aws_secret_access_key=je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY
 I often need to include an AWS key id and secret in deployment scripts. Yet I don't want to actually include the credentials in the script or in the git repository. Many AWS client support storing AWS credentials in an `~/.aws/credentials` files and using a `--profile` argument or `AWS_DEFAULT_PROFILE` environment variable. However other tools only work by setting the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. Sometimes you need to inject these credentials into stored secrets or configurations. This script helps script these tasks whilst keeping the credentials out of your scripts and repository. I wanted a pure bash solution I could include in automated build and deployment environments.
 
 # Credits
-The really cool part of this script is the ['ini' file parser written by Andres J. Diaz](http://theoldschooldevops.com/2008/02/09/bash-ini-parser/).
+The really cool part of this script is the ['ini' file parser written by Andres J. Diaz](https://web.archive.org/web/20180826221418/http://theoldschooldevops.com/2008/02/09/bash-ini-parser/).


### PR DESCRIPTION
Update credits URL to point to latest version from Internet Archive, as current URL is returning an error (`curl http://theoldschooldevops.com/2008/02/09/bash-ini-parser/ -> 您要找的资源已被删除、已更名或暂时不可用 -> The resource you are looking for has been deleted, renamed, or temporarily unavailable`).